### PR TITLE
Provide realtime state for history sources

### DIFF
--- a/src/hass_energy/lib/source_resolver/hass_provider.py
+++ b/src/hass_energy/lib/source_resolver/hass_provider.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import datetime as dt
 from typing import TypedDict
 
@@ -19,6 +20,12 @@ class HomeAssistantHistoryStateDict(TypedDict, total=False):
     last_changed: str
     last_reported: str
     last_updated: str
+
+
+@dataclass(frozen=True)
+class HomeAssistantHistoryPayload:
+    history: list[HomeAssistantHistoryStateDict]
+    current_state: HomeAssistantStateDict
 
 
 class HassDataProvider:

--- a/tests/hass_energy/lib/source_resolver/test_hass_source.py
+++ b/tests/hass_energy/lib/source_resolver/test_hass_source.py
@@ -9,6 +9,7 @@ from hass_energy.lib.source_resolver.hass_source import (
     HomeAssistantAmberElectricForecastSource,
     HomeAssistantHistoricalAverageForecastSource,
 )
+from hass_energy.lib.source_resolver.hass_provider import HomeAssistantHistoryPayload
 
 
 def _freeze_hass_source_time(monkeypatch: pytest.MonkeyPatch, frozen: datetime) -> None:
@@ -54,8 +55,18 @@ def test_historical_average_wraps_for_longer_horizon(
             "state": 1.0,
         },
     ]
+    current_state = {
+        "entity_id": "sensor.load",
+        "state": 1.0,
+        "attributes": {"unit_of_measurement": "kW"},
+        "last_changed": now.isoformat(),
+        "last_reported": now.isoformat(),
+        "last_updated": now.isoformat(),
+    }
 
-    intervals = source.mapper(history)
+    intervals = source.mapper(
+        HomeAssistantHistoryPayload(history=history, current_state=current_state)
+    )
 
     assert len(intervals) == 48
     assert intervals[0].start == datetime(2025, 1, 2, 6, 0, tzinfo=UTC)
@@ -66,6 +77,63 @@ def test_historical_average_wraps_for_longer_horizon(
     assert intervals[24].value == pytest.approx(1.0)
     assert intervals[30].start == datetime(2025, 1, 3, 12, 0, tzinfo=UTC)
     assert intervals[30].value == pytest.approx(2.0)
+
+
+def test_historical_average_smooths_realtime_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2025, 1, 2, 6, 30, tzinfo=UTC)
+    _freeze_hass_source_time(monkeypatch, now)
+
+    source = HomeAssistantHistoricalAverageForecastSource(
+        type="home_assistant",
+        platform="historical_average",
+        entity="load_forecast",
+        history_days=2,
+        unit="kW",
+        interval_duration=60,
+        forecast_horizon_hours=3,
+        realtime_window_minutes=120,
+    )
+
+    history = [
+        {
+            "last_updated": datetime(2025, 1, 1, 7, 0, tzinfo=UTC).isoformat(),
+            "state": 1.0,
+        },
+        {
+            "last_updated": datetime(2025, 1, 1, 8, 0, tzinfo=UTC).isoformat(),
+            "state": 1.0,
+        },
+        {
+            "last_updated": datetime(2025, 1, 2, 5, 0, tzinfo=UTC).isoformat(),
+            "state": 1.0,
+        },
+        {
+            "last_updated": datetime(2025, 1, 2, 6, 0, tzinfo=UTC).isoformat(),
+            "state": 1.0,
+        },
+    ]
+    current_state = {
+        "entity_id": "sensor.load",
+        "state": 3.0,
+        "attributes": {"unit_of_measurement": "kW"},
+        "last_changed": now.isoformat(),
+        "last_reported": now.isoformat(),
+        "last_updated": now.isoformat(),
+    }
+
+    intervals = source.mapper(
+        HomeAssistantHistoryPayload(history=history, current_state=current_state)
+    )
+
+    assert len(intervals) == 3
+    assert intervals[0].start == datetime(2025, 1, 2, 6, 0, tzinfo=UTC)
+    assert intervals[0].value == pytest.approx(3.0)
+    assert intervals[1].start == datetime(2025, 1, 2, 7, 0, tzinfo=UTC)
+    assert intervals[1].value == pytest.approx(2.5)
+    assert intervals[2].start == datetime(2025, 1, 2, 8, 0, tzinfo=UTC)
+    assert intervals[2].value == pytest.approx(1.5)
 
 
 def test_amber_forecast_falls_back_to_per_kwh_when_advanced_missing() -> None:


### PR DESCRIPTION
### Motivation

- Align history-source interfaces so historical mappers can receive realtime state alongside history for smoothing or anchoring.  
- Make `current_state` consistently available to history mappers instead of optional to avoid branching logic in implementors.  
- Ensure realtime state is fetched/marked when history is requested so smoothing data is available.  
- Fix the earlier interface mismatch where only one historical implementation received realtime data.

### Description

- Make `HomeAssistantHistoryPayload` include a non-optional `current_state` and use it as the input type for `HomeAssistantHistoryEntitySource`.  
- Update `HomeAssistantHistoricalAverageForecastSource.mapper` to accept a `HomeAssistantHistoryPayload`, extract `current_state`, and perform realtime smoothing via `_apply_realtime_smoothing`.  
- Change `ValueResolver.resolve` to always build and pass a `HomeAssistantHistoryPayload` (fetching the realtime state) when resolving history sources, and update `mark` to mark realtime entities for all history sources.  
- Update unit tests and test stubs to provide and expect `current_state` and exercise realtime-smoothing and marking behavior.

### Testing

- Ran `uv run pytest tests/hass_energy/lib/source_resolver` and all tests passed (`13 passed`).  
- Added/updated tests including `test_historical_average_smooths_realtime_override` and `test_mark_for_hydration_marks_realtime_when_window_configured`.  
- Resolver tests verify realtime state is marked/fetched for history sources and succeeded.  
- No automated test failures observed in the changed test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e3cb575d08331865b7297f37e21b6)