### PR TITLE
Include custom_components in CI linting and typechecking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Sync dependencies
         run: uv sync --dev --frozen
       - name: Lint
-        run: uv run ruff check src
+        run: uv run ruff check src custom_components
   typecheck:
     runs-on: ubuntu-latest
     steps:
@@ -33,7 +33,7 @@ jobs:
       - name: Sync dependencies
         run: uv sync --dev --frozen
       - name: Type check
-        run: uv run pyright
+        run: uv run pyright src custom_components
   tests:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ build-backend = "uv_build"
 [tool.ruff]
 line-length = 100
 target-version = "py313"
-src = ["src"]
+src = ["src", "custom_components"]
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "I", "UP"]


### PR DESCRIPTION
### Motivation
- Ensure the Home Assistant integration under `custom_components` is statically checked alongside the package sources.
- Prevent regressions and enforce consistent style/type rules for the custom integration code.

### Description
- Updated `.github/workflows/ci.yml` to run `uv run ruff check src custom_components` in the lint job and `uv run pyright src custom_components` in the typecheck job.
- Added `custom_components` to the `src` roots in `[tool.ruff]` inside `pyproject.toml` so ruff treats it as a source directory.

### Testing
- No automated tests were run locally; CI will execute the pipeline on push/PR.
- The CI jobs will run `uv run ruff check src custom_components`, `uv run pyright src custom_components`, and `uv run pytest` when triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e538abd48331984259b8b7556802)