### PR TITLE
docs: add worktree setup note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - Shared helpers (e.g., Home Assistant client) live under `hass_energy/lib/` to keep worker/API code lean.
 - CLI accepts a YAML config (`--config`, default `config.yaml`) for static settings like host, port, and data_dir. Config is validated with Pydantic. Worker is always on; host/port flags were removed.
 - Systemd units should use an absolute path to `uv` in `ExecStart` when `uv` is installed under a user-local path (e.g., `/root/.local/bin/uv`), because systemd only searches a limited set of system paths.
+- For self-contained tasks when requested, create a git worktree under `.worktrees/<meaningful-name>`, copy `config.dev.yaml` into the worktree root, and run `uv sync` there before starting work.
 - Routes are split by domain under `hass_energy/api/routes/` (e.g., `plan`, `settings`). Settings endpoint surfaces runtime energy settings (read-only; user edits YAML).
 - MILP logic lives under `hass_energy/worker/milp/` using PuLP; planner/compiler are placeholders awaiting real constraints.
 - MILP v2 scaffolding lives under `src/hass_energy/milp_v2/` with a compile phase (config + `ValueResolver` -> `CompiledModel`) and an execute phase (solve -> `PlanResult`).


### PR DESCRIPTION
## Summary
- document the standard worktree setup process for self-contained tasks

## Testing
- not run