### PR TITLE
Split throughput_cost_per_kwh into charge/discharge costs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
 - When config schemas change in backward-incompatible ways, update any captured scenario configs under `tests/fixtures/ems/**/ems_config.yaml` to keep fixture tests passing.
 - EMS-specific guidance lives in `src/hass_energy/ems/AGENTS.md`.
 - EMS plan `EconomicsTimestepPlan` costs are grid import/export only and exclude other objective terms (EV incentives, penalties, curtailment tie-breaks, violation penalties, battery wear).
-- EMS objective favors self-consumption via `self_consumption_bias_pct` (adds premium to import, discounts export). Battery throughput cost applies to discharge only.
+- EMS objective favors self-consumption via `self_consumption_bias_pct` (adds premium to import, discounts export). Battery wear cost (`charge_cost_per_kwh`, `discharge_cost_per_kwh`) allows separate cost per kWh for charge and discharge.
 - `EmsPlanOutput` now includes `objective_value` with the solver objective (may be negative/None).
 - Load-aware curtailment is forced on whenever export price is negative, enabling PV to follow load and blocking export for those slots.
 - EMS horizons can use `EmsConfig.timestep_minutes` plus `high_res_timestep_minutes` / `high_res_horizon_minutes` to run a higher-resolution window before switching to the default timestep; boundaries snap to the next interval boundary for aligned coarse slots and alignment uses time-weighted averages for variable slot sizes.

--- a/src/hass_energy/ems/AGENTS.md
+++ b/src/hass_energy/ems/AGENTS.md
@@ -100,9 +100,9 @@ model at the start of the horizon:
   - Self-consumption bias (`plant.load.self_consumption_bias_pct`) adds a premium to import prices and discount to export revenue, favoring local consumption.
 - Forbidden import violations:
   - Large penalty on `P_grid_import_violation_kw`.
-- Battery wear (discharge only):
-  - `throughput_cost_per_kwh` applied to **discharge only** (not charge).
-  - Charging is not penalized so PV energy is captured freely.
+- Battery wear:
+  - `discharge_cost_per_kwh` applied to discharge, `charge_cost_per_kwh` applied to charge.
+  - Both default to 0.0; set `charge_cost_per_kwh: 0.0` to capture PV energy freely.
   - Efficiency losses are already in the SoC dynamics constraints.
 - Terminal SoC shortfall penalty:
   - Applied when the terminal constraint is softened; default penalty uses the average

--- a/src/hass_energy/ems/EMS_SYSTEM_DESIGN.md
+++ b/src/hass_energy/ems/EMS_SYSTEM_DESIGN.md
@@ -128,7 +128,7 @@ Fields:
 
 - `capacity_kwh`
 - `storage_efficiency_pct`
-- `throughput_cost_per_kwh`
+- `charge_cost_per_kwh`, `discharge_cost_per_kwh`
 - `min_soc_pct`, `max_soc_pct`, `reserve_soc_pct`
 - `max_charge_kw`, `max_discharge_kw` (optional)
 - `state_of_charge_pct` (realtime)
@@ -362,7 +362,7 @@ The objective is a sum of:
 3. **Early-flow tie-breaker**:
    - Tiny negative weight on `(P_import + P_export) / (t+1)` to bias flow earlier.
 4. **Battery wear cost**:
-   - `throughput_cost_per_kwh * (charge + discharge)`.
+   - `charge_cost_per_kwh * charge + discharge_cost_per_kwh * discharge`.
 5. **Curtailment tie-breaker**:
    - Small weighted bias on `Curtail_inv` to stabilize equivalent solutions.
 6. **EV incentive rewards**:

--- a/src/hass_energy/ems/builder.py
+++ b/src/hass_energy/ems/builder.py
@@ -607,15 +607,21 @@ class MILPBuilder:
             if inv_vars is None:
                 continue
             discharge_series = inv_vars.P_batt_discharge_kw
-            if discharge_series is None:
+            charge_series = inv_vars.P_batt_charge_kw
+            if discharge_series is None or charge_series is None:
                 continue
-            wear_cost = battery.throughput_cost_per_kwh
-            if wear_cost <= 0:
-                continue
-            objective += pulp.lpSum(
-                wear_cost * discharge_series[t] * horizon.dt_hours(t)
-                for t in horizon.T
-            )
+            discharge_cost = battery.discharge_cost_per_kwh
+            charge_cost = battery.charge_cost_per_kwh
+            if discharge_cost > 0:
+                objective += pulp.lpSum(
+                    discharge_cost * discharge_series[t] * horizon.dt_hours(t)
+                    for t in horizon.T
+                )
+            if charge_cost > 0:
+                objective += pulp.lpSum(
+                    charge_cost * charge_series[t] * horizon.dt_hours(t)
+                    for t in horizon.T
+                )
         terminal_penalty = self._terminal_soc_penalty_per_kwh(horizon, price_import)
         if terminal_penalty > 0:
             for inverter in self._plant.inverters:

--- a/src/hass_energy/models/plant.py
+++ b/src/hass_energy/models/plant.py
@@ -60,7 +60,8 @@ class PvConfig(BaseModel):
 class BatteryConfig(BaseModel):
     capacity_kwh: float = Field(ge=0)
     storage_efficiency_pct: float = Field(gt=0, le=100)
-    throughput_cost_per_kwh: float = Field(default=0.0, ge=0)
+    charge_cost_per_kwh: float = Field(default=0.0, ge=0)
+    discharge_cost_per_kwh: float = Field(default=0.0, ge=0)
     min_soc_pct: float = Field(ge=0, le=100)
     max_soc_pct: float = Field(ge=0, le=100)
     reserve_soc_pct: float = Field(ge=0, le=100)

--- a/tests/fixtures/ems/20260117-120518/ems_config.yaml
+++ b/tests/fixtures/ems/20260117-120518/ems_config.yaml
@@ -75,7 +75,8 @@ plant:
     battery:
       capacity_kwh: 41.9
       storage_efficiency_pct: 95.0
-      throughput_cost_per_kwh: 0.01
+      charge_cost_per_kwh: 0.0
+      discharge_cost_per_kwh: 0.01
       min_soc_pct: 11.0
       max_soc_pct: 100.0
       reserve_soc_pct: 30.0

--- a/tests/fixtures/ems/arbitrage-opportunity/ems_config.yaml
+++ b/tests/fixtures/ems/arbitrage-opportunity/ems_config.yaml
@@ -76,7 +76,8 @@ plant:
     battery:
       capacity_kwh: 41.9
       storage_efficiency_pct: 95.0
-      throughput_cost_per_kwh: 0.01
+      charge_cost_per_kwh: 0.0
+      discharge_cost_per_kwh: 0.01
       min_soc_pct: 11.0
       max_soc_pct: 100.0
       reserve_soc_pct: 30.0

--- a/tests/fixtures/ems/current-20260114-204101/ems_config.yaml
+++ b/tests/fixtures/ems/current-20260114-204101/ems_config.yaml
@@ -76,7 +76,8 @@ plant:
     battery:
       capacity_kwh: 41.9
       storage_efficiency_pct: 95.0
-      throughput_cost_per_kwh: 0.02
+      charge_cost_per_kwh: 0.0
+      discharge_cost_per_kwh: 0.02
       min_soc_pct: 11.0
       max_soc_pct: 100.0
       reserve_soc_pct: 30.0

--- a/tests/fixtures/ems/ems_config.yaml
+++ b/tests/fixtures/ems/ems_config.yaml
@@ -90,7 +90,8 @@ plant:
       battery:
         capacity_kwh: 41.9
         storage_efficiency_pct: 96.0 # Charge/discharge storage efficiency
-        throughput_cost_per_kwh: 0.01 # Wear cost per kWh charged or discharged
+        charge_cost_per_kwh: 0.0
+        discharge_cost_per_kwh: 0.01 # Wear cost per kWh charged or discharged
         min_soc_pct: 11.0
         max_soc_pct: 100.0
 

--- a/tests/fixtures/ems/long-horizon-terminal-charge-up/ems_config.yaml
+++ b/tests/fixtures/ems/long-horizon-terminal-charge-up/ems_config.yaml
@@ -76,7 +76,8 @@ plant:
     battery:
       capacity_kwh: 41.9
       storage_efficiency_pct: 95.0
-      throughput_cost_per_kwh: 0.01
+      charge_cost_per_kwh: 0.0
+      discharge_cost_per_kwh: 0.01
       min_soc_pct: 11.0
       max_soc_pct: 100.0
       reserve_soc_pct: 30.0

--- a/tests/fixtures/ems/short-horizon-2-surplus-energy/ems_config.yaml
+++ b/tests/fixtures/ems/short-horizon-2-surplus-energy/ems_config.yaml
@@ -76,7 +76,8 @@ plant:
     battery:
       capacity_kwh: 41.9
       storage_efficiency_pct: 95.0
-      throughput_cost_per_kwh: 0.01
+      charge_cost_per_kwh: 0.0
+      discharge_cost_per_kwh: 0.01
       min_soc_pct: 11.0
       max_soc_pct: 100.0
       reserve_soc_pct: 30.0

--- a/tests/fixtures/ems/short-horizon-low-pv/ems_config.yaml
+++ b/tests/fixtures/ems/short-horizon-low-pv/ems_config.yaml
@@ -76,7 +76,8 @@ plant:
     battery:
       capacity_kwh: 41.9
       storage_efficiency_pct: 95.0
-      throughput_cost_per_kwh: 0.01
+      charge_cost_per_kwh: 0.0
+      discharge_cost_per_kwh: 0.01
       min_soc_pct: 11.0
       max_soc_pct: 100.0
       reserve_soc_pct: 30.0

--- a/tests/fixtures/ems/short-horizon/ems_config.yaml
+++ b/tests/fixtures/ems/short-horizon/ems_config.yaml
@@ -76,7 +76,8 @@ plant:
     battery:
       capacity_kwh: 41.9
       storage_efficiency_pct: 95.0
-      throughput_cost_per_kwh: 0.01
+      charge_cost_per_kwh: 0.0
+      discharge_cost_per_kwh: 0.01
       min_soc_pct: 11.0
       max_soc_pct: 100.0
       reserve_soc_pct: 30.0


### PR DESCRIPTION
Replace single `throughput_cost_per_kwh` with separate:
- `charge_cost_per_kwh`: cost per kWh charged (default 0.0)
- `discharge_cost_per_kwh`: cost per kWh discharged (default 0.0)

This allows users to configure different wear costs for charging vs discharging, enabling scenarios like free PV charging while still penalizing discharge cycles.

**Changes:**
- Updated `BatteryConfig` model with new fields
- Updated EMS builder to apply both costs independently
- Updated all fixture configs and regenerated baselines (no plan changes)
- Updated documentation (AGENTS.md, EMS_SYSTEM_DESIGN.md, ems/AGENTS.md)