### PR TITLE
Allow EMS scenario paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 - `hass_energy/worker/milp/ha_dump.py` now emits a single-battery stub in realtime inputs when `battery_soc` is available (capacity/limits are currently constants).
 - `hass_energy/worker/milp/ha_dump.py` emits a simple EV stub when `ev_connected` is true (defaults for capacity, target SOC, max power, value-per-kWh, min power, and switch penalty).
 - Tests should mirror the `src/hass_energy` package structure under `tests/` (e.g., `tests/hass_energy/ems/`).
-- EMS fixture snapshots use summarized `tests/fixtures/ems/**/ems_plan.json` baselines (single source of truth). Refresh with `hass-energy ems refresh-baseline --name <scenario>` and use `--force-image` when the plan hash is unchanged but you still need to regenerate plot images (e.g., plotting-only tweaks).
+- EMS fixture snapshots use summarized `tests/fixtures/ems/**/ems_plan.json` baselines (single source of truth). Refresh with `hass-energy ems refresh-baseline --name <name-or-path>` and use `--force-image` when the plan hash is unchanged but you still need to regenerate plot images (e.g., plotting-only tweaks).
 - Planner now consumes a resolved payload (no source models). Resolved schemas live in `src/hass_energy/models/resolved.py`; resolution scaffolding/registry is under `src/hass_energy/lib/resolution/` for two-pass fetch→transform in the future.
 - This is unreleased software; schema changes can be breaking without backward-compatibility shims.
 - When config schemas change in backward-incompatible ways, update any captured scenario configs under `tests/fixtures/ems/**/ems_config.yaml` to keep fixture tests passing.

--- a/src/hass_energy/cli.py
+++ b/src/hass_energy/cli.py
@@ -167,14 +167,14 @@ def ems(ctx: click.Context) -> None:
     "--scenario",
     type=str,
     default=None,
-    help="Replay a recorded scenario from tests/fixtures/ems/<name>.",
+    help="Replay a recorded scenario by name or by path to the scenario directory.",
 )
 @click.option(
     "--scenario-dir",
     type=click.Path(path_type=Path, file_okay=False),
     default=Path("tests/fixtures/ems"),
     show_default=True,
-    help="Base directory containing scenario bundles.",
+    help="Base directory containing scenario bundles when using a name.",
 )
 @click.pass_context
 def ems_solve(
@@ -364,7 +364,7 @@ def ems_record_scenario(
     "--name",
     type=str,
     required=True,
-    help="Scenario name to refresh.",
+    help="Scenario name or path to the scenario directory.",
 )
 @click.option(
     "--scenario-dir",

--- a/src/hass_energy/ems/AGENTS.md
+++ b/src/hass_energy/ems/AGENTS.md
@@ -144,16 +144,16 @@ Plotting (`src/hass_energy/plotting/plan.py`):
   `hass-energy ems record-scenario` (writes `ems_fixture.json`, `ems_config.yaml`,
   a summarized `ems_plan.json` baseline, `ems_plan.hash`, and `ems_plan.jpeg`
   under `tests/fixtures/ems/`; `--name` writes to a subdir).
-- Replay fixtures offline via `hass-energy ems solve --scenario <name>` to view
+- Replay fixtures offline via `hass-energy ems solve --scenario <name-or-path>` to view
   plots or output JSON without a live Home Assistant connection.
 - When making EMS changes, validate against a checked-in fixture by replaying it
   and comparing the generated plan summary to the stored `ems_plan.json` for the
   same scenario. This is the preferred offline sanity check before updating snapshots.
   Example workflow:
-  - `hass-energy ems solve --scenario <name> --output /tmp/ems_plan.actual.json`
+  - `hass-energy ems solve --scenario <name-or-path> --output /tmp/ems_plan.actual.json`
   - Use `/tmp/ems_plan.actual.json` for deep debugging; the checked-in
     `tests/fixtures/ems/<name>/ems_plan.json` is a summarized baseline for diffs.
-  - Refresh the summarized baseline with `hass-energy ems refresh-baseline --name <name>`.
+  - Refresh the summarized baseline with `hass-energy ems refresh-baseline --name <name-or-path>`.
   - For visual inspection, add `--plot` or `--plot-output <path>` to review the plan.
 - The `ems_plan.jpeg` image is checked in for PR review; it regenerates only when
   the plan hash changes. The hash file (`ems_plan.hash`) stores a SHA256 prefix

--- a/src/hass_energy/ems/EMS_SYSTEM_DESIGN.md
+++ b/src/hass_energy/ems/EMS_SYSTEM_DESIGN.md
@@ -448,8 +448,8 @@ EMS tests live under `tests/hass_energy/ems/`:
 Fixtures can be recorded via:
 
 - `hass-energy ems record-scenario --name <scenario>`
-- `hass-energy ems refresh-baseline --name <scenario>`
-- `hass-energy ems solve --scenario <name>`
+- `hass-energy ems refresh-baseline --name <name-or-path>`
+- `hass-energy ems solve --scenario <name-or-path>`
 
 ---
 

--- a/src/hass_energy/ems/fixture_harness.py
+++ b/src/hass_energy/ems/fixture_harness.py
@@ -21,8 +21,21 @@ class EmsFixturePaths:
     hash_path: Path
 
 
-def resolve_ems_fixture_paths(base_dir: Path, name: str | None) -> EmsFixturePaths:
-    root_dir = base_dir / name if name else base_dir
+def _resolve_fixture_root(base_dir: Path, name: str | Path) -> Path:
+    candidate = Path(name)
+    if candidate.is_absolute():
+        return candidate
+
+    base_candidate = base_dir / candidate
+    if base_candidate.exists():
+        return base_candidate
+    if candidate.exists():
+        return candidate
+    return base_candidate
+
+
+def resolve_ems_fixture_paths(base_dir: Path, name: str | Path | None) -> EmsFixturePaths:
+    root_dir = base_dir if name is None else _resolve_fixture_root(base_dir, name)
     return EmsFixturePaths(
         root_dir=root_dir,
         fixture_path=root_dir / "ems_fixture.json",

--- a/tests/hass_energy/ems/test_fixture_harness.py
+++ b/tests/hass_energy/ems/test_fixture_harness.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pytest import MonkeyPatch
+
+from hass_energy.ems.fixture_harness import resolve_ems_fixture_paths
+
+
+def test_resolve_ems_fixture_paths_name_uses_base_dir(tmp_path: Path) -> None:
+    base_dir = tmp_path / "fixtures"
+    scenario_dir = base_dir / "scenario-a"
+    scenario_dir.mkdir(parents=True)
+
+    paths = resolve_ems_fixture_paths(base_dir, "scenario-a")
+
+    assert paths.root_dir == scenario_dir
+
+
+def test_resolve_ems_fixture_paths_absolute_path(tmp_path: Path) -> None:
+    base_dir = tmp_path / "fixtures"
+    base_dir.mkdir(parents=True)
+    scenario_dir = tmp_path / "scenario-b"
+    scenario_dir.mkdir(parents=True)
+
+    paths = resolve_ems_fixture_paths(base_dir, str(scenario_dir))
+
+    assert paths.root_dir == scenario_dir
+
+
+def test_resolve_ems_fixture_paths_relative_path(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    base_dir = tmp_path / "fixtures"
+    base_dir.mkdir(parents=True)
+    scenario_dir = tmp_path / "scenario-c"
+    scenario_dir.mkdir(parents=True)
+
+    monkeypatch.chdir(tmp_path)
+    rel_path = Path("scenario-c")
+
+    paths = resolve_ems_fixture_paths(base_dir, str(rel_path))
+
+    assert paths.root_dir == rel_path
+    assert paths.root_dir.resolve() == scenario_dir.resolve()
+
+
+def test_resolve_ems_fixture_paths_nested_name_defaults_to_base_dir(tmp_path: Path) -> None:
+    base_dir = tmp_path / "fixtures"
+    base_dir.mkdir(parents=True)
+
+    paths = resolve_ems_fixture_paths(base_dir, "nested/scenario-d")
+
+    assert paths.root_dir == base_dir / "nested/scenario-d"


### PR DESCRIPTION
## Summary
- allow EMS scenario CLI options to accept a scenario directory path as well as a name
- add fixture harness tests for path resolution behavior
- update EMS docs and CLI help text to reflect path support

## Testing
- uv run ruff check src custom_components tests
- uv run pyright src custom_components tests
- uv run pytest
