### PR TITLE
Remove self-consumption bias setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - When config schemas change in backward-incompatible ways, the shared `tests/fixtures/ems/<fixture>/ems_config.yaml` must be updated to keep fixture tests passing.
 - EMS-specific guidance lives in `src/hass_energy/ems/AGENTS.md`.
 - EMS plan `EconomicsTimestepPlan` costs are grid import/export only and exclude other objective terms (EV incentives, penalties, curtailment tie-breaks, violation penalties, battery wear).
-- EMS objective favors self-consumption via `self_consumption_bias_pct` (adds premium to import, discounts export). Battery wear cost (`charge_cost_per_kwh`, `discharge_cost_per_kwh`) allows separate cost per kWh for charge and discharge.
+- Battery wear cost (`charge_cost_per_kwh`, `discharge_cost_per_kwh`) allows separate cost per kWh for charge and discharge.
 - `EmsPlanOutput` now includes `objective_value` with the solver objective (may be negative/None).
 - Load-aware curtailment is forced on whenever export price is negative, enabling PV to follow load and blocking export for those slots.
 - EMS horizons can use `EmsConfig.timestep_minutes` plus `high_res_timestep_minutes` / `high_res_horizon_minutes` to run a higher-resolution window before switching to the default timestep; boundaries snap to the next interval boundary for aligned coarse slots and alignment uses time-weighted averages for variable slot sizes.

--- a/src/hass_energy/ems/AGENTS.md
+++ b/src/hass_energy/ems/AGENTS.md
@@ -97,7 +97,6 @@ model at the start of the horizon:
 ### Objective (current terms)
 - Energy cost:
   - `import_cost - export_revenue` (with a tiny export bonus when price = 0).
-  - Self-consumption bias (`plant.load.self_consumption_bias_pct`) adds a premium to import prices and discount to export revenue, favoring local consumption.
 - Forbidden import violations:
   - Large penalty on `P_grid_import_violation_kw`.
 - Battery wear:
@@ -116,7 +115,6 @@ model at the start of the horizon:
     the horizon ratio vs `terminal_soc.short_horizon_minutes`.
 - EV SoC incentives:
   - Piecewise per-kWh rewards for reaching terminal SoC targets.
-  - Incentives are scaled by `(1 - self_consumption_bias)` so they compete fairly with export tariffs (an 8c incentive ties with an 8c export tariff).
 - Early-flow tie-breaker:
   - Small time-decay bonus on total grid flow `(P_import + P_export)` favoring earlier slots.
 - Curtailment energy cost:

--- a/src/hass_energy/ems/builder.py
+++ b/src/hass_energy/ems/builder.py
@@ -648,27 +648,20 @@ class MILPBuilder:
         inverter_by_id = inverters.inverters
         ev_by_id = loads.evs
 
-        # Self-consumption bias: add premium to import, discount export.
-        self_consumption_bias = self._plant.load.self_consumption_bias_pct / 100.0
-
         # Price-aware objective: minimize net cost (import cost minus export revenue).
         # When export price is exactly zero, add a tiny bonus to prefer exporting over curtailment.
-        # Self-consumption bias makes grid interaction slightly less attractive than local use.
         export_bonus = 1e-4
         # Effective export price series used consistently for revenue and penalties.
         export_price_eff = [
             (
                 export_bonus
                 if abs(float(price_export[t])) <= 1e-9
-                else float(price_export[t]) * (1.0 - self_consumption_bias)
+                else float(price_export[t])
             )
             for t in horizon.T
         ]
         objective: pulp.LpAffineExpression = pulp.lpSum(
-            (
-                P_import[t] * float(price_import[t]) * (1.0 + self_consumption_bias)
-                - P_export[t] * export_price_eff[t]
-            )
+            (P_import[t] * float(price_import[t]) - P_export[t] * export_price_eff[t])
             * horizon.dt_hours(t)
             for t in horizon.T
         )
@@ -776,14 +769,11 @@ class MILPBuilder:
                 for t in horizon.T
             )
         # EV terminal SoC incentives (piecewise per-kWh rewards).
-        # Apply the same bias as export revenue so incentives compete fairly with export tariffs.
-        # e.g., an 8c incentive should tie with an 8c export tariff after both are biased.
         for segments in loads.ev_incentive_segments.values():
             for segment_var, incentive in segments:
                 if abs(float(incentive)) <= 1e-12:
                     continue
-                biased_incentive = float(incentive) * (1.0 - self_consumption_bias)
-                objective += -biased_incentive * segment_var
+                objective += -float(incentive) * segment_var
         # EV ramp penalties (discourage large per-slot changes in charge power).
         ramp_penalty = _EV_RAMP_PENALTY_COST
         for load in self._loads:

--- a/src/hass_energy/models/plant.py
+++ b/src/hass_energy/models/plant.py
@@ -42,11 +42,6 @@ class GridConfig(BaseModel):
 class PlantLoadConfig(BaseModel):
     realtime_load_power: HomeAssistantPowerKwEntitySource
     forecast: HomeAssistantHistoricalAverageForecastSource
-
-    # Self-consumption bias: add a premium to import prices and discount to
-    # export revenue to favor serving loads from local generation/storage.
-    self_consumption_bias_pct: float = Field(default=0.0, ge=0, le=100)
-
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
 

--- a/tests/fixtures/ems/nwhass/ems_config.yaml
+++ b/tests/fixtures/ems/nwhass/ems_config.yaml
@@ -55,7 +55,6 @@ plant:
       interval_duration: 5
       forecast_horizon_hours: 48
       realtime_window_minutes: 180
-    self_consumption_bias_pct: 0.0
   inverters:
   - id: primary
     name: Primary


### PR DESCRIPTION
- Remove self_consumption_bias_pct from plant config and objective math
- Drop bias scaling from EV incentives and docs
- Update EMS fixture configs and refresh baselines

Tests:
- uv run hass-energy ems refresh-baseline