### PR TITLE
Consolidate battery wear cost and rename export margin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - When config schemas change in backward-incompatible ways, the shared `tests/fixtures/ems/<fixture>/ems_config.yaml` must be updated to keep fixture tests passing.
 - EMS-specific guidance lives in `src/hass_energy/ems/AGENTS.md`.
 - EMS plan `EconomicsTimestepPlan` costs are grid import/export only and exclude other objective terms (EV incentives, penalties, curtailment tie-breaks, violation penalties, battery wear).
-- Battery wear cost (`charge_cost_per_kwh`, `discharge_cost_per_kwh`) allows separate cost per kWh for charge and discharge.
+- Battery wear cost (`wear_cost_per_kwh`) applies symmetrically to charge and discharge.
 - `EmsPlanOutput` now includes `objective_value` with the solver objective (may be negative/None).
 - Load-aware curtailment is forced on whenever export price is negative, enabling PV to follow load and blocking export for those slots.
 - EMS horizons can use `EmsConfig.timestep_minutes` plus `high_res_timestep_minutes` / `high_res_horizon_minutes` to run a higher-resolution window before switching to the default timestep; boundaries snap to the next interval boundary for aligned coarse slots and alignment uses time-weighted averages for variable slot sizes.

--- a/src/hass_energy/ems/AGENTS.md
+++ b/src/hass_energy/ems/AGENTS.md
@@ -100,12 +100,12 @@ model at the start of the horizon:
 - Forbidden import violations:
   - Large penalty on `P_grid_import_violation_kw`.
 - Battery wear:
-  - `discharge_cost_per_kwh` applied to discharge, `charge_cost_per_kwh` applied to charge.
-  - Both default to 0.0; set `charge_cost_per_kwh: 0.0` to capture PV energy freely.
+  - `wear_cost_per_kwh` applied symmetrically to charge and discharge.
+  - Defaults to 0.0; increase to penalize battery throughput.
   - Efficiency losses are already in the SoC dynamics constraints.
-- Battery export penalty (optional):
-  - `export_penalty_per_kwh` applied to battery export flow (battery → grid).
-  - Configure per inverter via `plant.inverters[].battery.export_penalty_per_kwh`.
+- Battery export margin (optional):
+  - `export_margin_per_kwh` adds an explicit cost to battery export flow (battery → grid).
+  - Configure per inverter via `plant.inverters[].battery.export_margin_per_kwh`.
 - Battery timing tie-breaker:
   - Tiny time-weighted throughput penalty to stabilize dispatch ordering across
     equivalent-cost slots.
@@ -120,7 +120,7 @@ model at the start of the horizon:
 - Curtailment energy cost:
   - Penalizes wasted PV power (difference between available and used).
   - Configurable per inverter via `plant.inverters[].curtailment_cost_per_kwh` (default 0.0).
-  - Should exceed battery `charge_cost_per_kwh` so charging is preferred over curtailing.
+  - Should exceed battery `wear_cost_per_kwh` so charging is preferred over curtailing.
 
 ### Outputs & plotting
 `planner.py` emits per-slot:

--- a/src/hass_energy/ems/EMS_SYSTEM_DESIGN.md
+++ b/src/hass_energy/ems/EMS_SYSTEM_DESIGN.md
@@ -128,7 +128,7 @@ Fields:
 
 - `capacity_kwh`
 - `storage_efficiency_pct`
-- `charge_cost_per_kwh`, `discharge_cost_per_kwh`
+- `wear_cost_per_kwh`
 - `min_soc_pct`, `max_soc_pct`, `reserve_soc_pct`
 - `max_charge_kw`, `max_discharge_kw` (optional)
 - `state_of_charge_pct` (realtime)
@@ -362,9 +362,9 @@ The objective is a sum of:
 3. **Early-flow tie-breaker**:
    - Tiny negative weight on `(P_import + P_export) / (t+1)` to bias flow earlier.
 4. **Battery wear cost**:
-   - `charge_cost_per_kwh * charge + discharge_cost_per_kwh * discharge`.
-5. **Battery export penalty** (optional):
-   - `export_penalty_per_kwh * battery_export` on battery-to-grid flow.
+   - `wear_cost_per_kwh * (charge + discharge)`.
+5. **Battery export margin** (optional):
+   - `export_margin_per_kwh * battery_export` as explicit economic cost on battery-to-grid flow.
 6. **Battery timing tie-breaker**:
    - Tiny time-weighted throughput penalty to stabilize dispatch ordering.
 7. **Curtailment tie-breaker**:

--- a/src/hass_energy/models/plant.py
+++ b/src/hass_energy/models/plant.py
@@ -55,12 +55,11 @@ class PvConfig(BaseModel):
 class BatteryConfig(BaseModel):
     capacity_kwh: float = Field(ge=0)
     storage_efficiency_pct: float = Field(gt=0, le=100)
-    charge_cost_per_kwh: float = Field(default=0.0, ge=0)
-    discharge_cost_per_kwh: float = Field(default=0.0, ge=0)
-    # Discourages low-value battery -> grid export without penalizing PV export.
+    wear_cost_per_kwh: float = Field(default=0.0, ge=0)
+    # Extra cost per kWh applied to battery -> grid export (part of economics).
     # Use when you want self-consumption to win over small arbitrage spreads but still
     # allow export at sufficiently high prices.
-    export_penalty_per_kwh: float = Field(default=0.0, ge=0)
+    export_margin_per_kwh: float = Field(default=0.0, ge=0)
     min_soc_pct: float = Field(ge=0, le=100)
     max_soc_pct: float = Field(ge=0, le=100)
     reserve_soc_pct: float = Field(ge=0, le=100)
@@ -85,7 +84,7 @@ class InverterConfig(BaseModel):
     name: str = Field(min_length=1)
     peak_power_kw: float = Field(ge=0)
     curtailment: Literal["load-aware", "binary"] | None = None
-    # Cost per kWh of curtailed PV; should exceed battery charge_cost_per_kwh
+    # Cost per kWh of curtailed PV; should exceed battery wear_cost_per_kwh
     # so the solver prefers charging over curtailing. Default 0.03 (3c/kWh).
     curtailment_cost_per_kwh: float = Field(default=0.0, ge=0)
     pv: PvConfig

--- a/tests/fixtures/ems/nwhass/ems_config.yaml
+++ b/tests/fixtures/ems/nwhass/ems_config.yaml
@@ -75,9 +75,8 @@ plant:
     battery:
       capacity_kwh: 41.9
       storage_efficiency_pct: 95.0
-      charge_cost_per_kwh: 0.02
-      discharge_cost_per_kwh: 0.02
-      export_penalty_per_kwh: 0.06
+      wear_cost_per_kwh: 0.02
+      export_margin_per_kwh: 0.06
       min_soc_pct: 11.0
       max_soc_pct: 100.0
       reserve_soc_pct: 30.0


### PR DESCRIPTION
## Summary
- replace battery wear cost with single `wear_cost_per_kwh` applied to charge + discharge
- rename `export_penalty_per_kwh` to `export_margin_per_kwh` and clarify it as an explicit economic cost
- update EMS docs and fixture config

## Testing
- not run (not requested)
