### PR TITLE
Move grid price bias into grid config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - When config schemas change in backward-incompatible ways, the shared `tests/fixtures/ems/<fixture>/ems_config.yaml` must be updated to keep fixture tests passing.
 - EMS-specific guidance lives in `src/hass_energy/ems/AGENTS.md`.
 - EMS plan `EconomicsTimestepPlan` costs are grid import/export only and exclude other objective terms (EV incentives, penalties, curtailment tie-breaks, violation penalties, battery wear).
-- EMS objective favors self-consumption via `self_consumption_bias_pct` (adds premium to import, discounts export). Battery wear cost (`charge_cost_per_kwh`, `discharge_cost_per_kwh`) allows separate cost per kWh for charge and discharge.
+- EMS objective applies a grid price bias via `plant.grid.grid_price_bias_pct` (adds premium to import, discounts export). Battery wear cost (`charge_cost_per_kwh`, `discharge_cost_per_kwh`) allows separate cost per kWh for charge and discharge.
 - `EmsPlanOutput` now includes `objective_value` with the solver objective (may be negative/None).
 - Load-aware curtailment is forced on whenever export price is negative, enabling PV to follow load and blocking export for those slots.
 - EMS horizons can use `EmsConfig.timestep_minutes` plus `high_res_timestep_minutes` / `high_res_horizon_minutes` to run a higher-resolution window before switching to the default timestep; boundaries snap to the next interval boundary for aligned coarse slots and alignment uses time-weighted averages for variable slot sizes.

--- a/src/hass_energy/ems/AGENTS.md
+++ b/src/hass_energy/ems/AGENTS.md
@@ -97,7 +97,7 @@ model at the start of the horizon:
 ### Objective (current terms)
 - Energy cost:
   - `import_cost - export_revenue` (with a tiny export bonus when price = 0).
-  - Self-consumption bias (`plant.load.self_consumption_bias_pct`) adds a premium to import prices and discount to export revenue, favoring local consumption.
+  - Grid price bias (`plant.grid.grid_price_bias_pct`) adds a premium to import prices and discount to export revenue, making grid interaction less attractive.
 - Forbidden import violations:
   - Large penalty on `P_grid_import_violation_kw`.
 - Battery wear:
@@ -113,7 +113,7 @@ model at the start of the horizon:
     the horizon ratio vs `terminal_soc.short_horizon_minutes`.
 - EV SoC incentives:
   - Piecewise per-kWh rewards for reaching terminal SoC targets.
-  - Incentives are scaled by `(1 - self_consumption_bias)` so they compete fairly with export tariffs (an 8c incentive ties with an 8c export tariff).
+  - Incentives are scaled by `(1 - grid_price_bias)` so they compete fairly with export tariffs (an 8c incentive ties with an 8c export tariff).
 - Early-flow tie-breaker:
   - Small time-decay bonus on total grid flow `(P_import + P_export)` favoring earlier slots.
 - Terminal SoC value:

--- a/src/hass_energy/ems/EMS_SYSTEM_DESIGN.md
+++ b/src/hass_energy/ems/EMS_SYSTEM_DESIGN.md
@@ -96,6 +96,7 @@ Fields used by EMS:
 - `max_import_kw`, `max_export_kw`
 - `realtime_price_import`, `realtime_price_export`
 - `price_import_forecast`, `price_export_forecast`
+- `grid_price_bias_pct` (premium on import, discount on export)
 - `import_forbidden_periods` (list of `TimeWindow`)
 
 Note: `realtime_grid_power` exists in config but is **not used** by the EMS solver.

--- a/src/hass_energy/models/plant.py
+++ b/src/hass_energy/models/plant.py
@@ -32,6 +32,9 @@ class GridConfig(BaseModel):
     realtime_price_export: HomeAssistantCurrencyEntitySource
     price_import_forecast: HomeAssistantAmberElectricForecastSource
     price_export_forecast: HomeAssistantAmberElectricForecastSource
+    # Grid price bias: add a premium to import prices and discount to
+    # export revenue to make grid interaction less attractive.
+    grid_price_bias_pct: float = Field(default=0.0, ge=0, le=100)
     import_forbidden_periods: list[TimeWindow] = Field(
         default_factory=_default_import_forbidden_periods
     )
@@ -42,10 +45,6 @@ class GridConfig(BaseModel):
 class PlantLoadConfig(BaseModel):
     realtime_load_power: HomeAssistantPowerKwEntitySource
     forecast: HomeAssistantHistoricalAverageForecastSource
-
-    # Self-consumption bias: add a premium to import prices and discount to
-    # export revenue to favor serving loads from local generation/storage.
-    self_consumption_bias_pct: float = Field(default=0.0, ge=0, le=100)
 
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 

--- a/tests/fixtures/ems/nwhass/ems_config.yaml
+++ b/tests/fixtures/ems/nwhass/ems_config.yaml
@@ -39,6 +39,7 @@ plant:
       entity: sensor.amber_feed_in_forecast
       platform: amberelectric
       price_forecast_mode: spot
+    grid_price_bias_pct: 25.0
     import_forbidden_periods:
     - start: '14:55'
       end: '21:05'
@@ -55,7 +56,6 @@ plant:
       interval_duration: 5
       forecast_horizon_hours: 48
       realtime_window_minutes: 180
-    self_consumption_bias_pct: 25.0
   inverters:
   - id: primary
     name: Primary


### PR DESCRIPTION
## Summary
- move grid price bias to `plant.grid.grid_price_bias_pct`
- wire EMS objective to the new field and refresh docs/fixtures

## Testing
- uv run ruff check src custom_components tests
- uv run pyright
- uv run pytest
