### PR TITLE
Clarify connector-agnostic positioning and add QUICK_START docs

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,0 +1,158 @@
+# Quick Start
+
+This guide walks through installing dependencies, creating a configuration file, and running the API + worker locally or in Docker.
+
+## Prerequisites
+- A Home Assistant instance with the sensors/entities you want to plan against.
+- [uv](https://github.com/astral-sh/uv) installed (`pip install uv`).
+
+## 1) Install dependencies
+```bash
+uv sync --all-extras --dev
+```
+
+## 2) Create `config.yaml`
+Energy Assistant reads a single YAML config at startup. By default it looks for `config.yaml`, then `config.dev.yaml` if no path is provided. The API is read-only for config, so edit the YAML directly when settings change.
+
+Use this starter configuration and replace the Home Assistant URLs/tokens/entities with your own:
+
+```yaml
+server:
+  host: 0.0.0.0
+  port: 6070
+  data_dir: ./data
+homeassistant:
+  base_url: "http://homeassistant.local:8123"
+  token: "YOUR_LONG_LIVED_ACCESS_TOKEN"
+  verify_tls: true
+  timeout_seconds: 30
+ems:
+  timestep_minutes: 60
+  min_horizon_minutes: 1440
+plant:
+  grid:
+    max_import_kw: 10.0
+    max_export_kw: 10.0
+    realtime_grid_power:
+      type: home_assistant
+      entity: sensor.grid_power
+    realtime_price_import:
+      type: home_assistant
+      entity: sensor.price_import
+    realtime_price_export:
+      type: home_assistant
+      entity: sensor.price_export
+    price_import_forecast:
+      type: home_assistant
+      platform: amberelectric
+      entity: sensor.price_import_forecast
+    price_export_forecast:
+      type: home_assistant
+      platform: amberelectric
+      entity: sensor.price_export_forecast
+  load:
+    realtime_load_power:
+      type: home_assistant
+      entity: sensor.load_power
+    forecast:
+      type: home_assistant
+      platform: historical_average
+      entity: sensor.load_power_15m
+      history_days: 3
+      interval_duration: 60
+      unit: W
+  inverters:
+    - id: inverter_1
+      name: Main Inverter
+      peak_power_kw: 5.0
+      pv:
+        forecast:
+          type: home_assistant
+          platform: solcast
+          entities:
+            - sensor.solcast_forecast_today
+            - sensor.solcast_forecast_tomorrow
+      battery:
+        capacity_kwh: 13.5
+        storage_efficiency_pct: 92
+        charge_cost_per_kwh: 0.0
+        discharge_cost_per_kwh: 0.0
+        min_soc_pct: 10
+        max_soc_pct: 100
+        reserve_soc_pct: 20
+        max_charge_kw: 5.0
+        max_discharge_kw: 5.0
+        state_of_charge_pct:
+          type: home_assistant
+          entity: sensor.battery_soc
+        realtime_power:
+          type: home_assistant
+          entity: sensor.battery_power
+loads:
+  - id: ev_charger
+    name: EV Charger
+    load_type: controlled_ev
+    min_power_kw: 1.4
+    max_power_kw: 7.2
+    energy_kwh: 40
+    connected:
+      type: home_assistant
+      entity: binary_sensor.ev_connected
+    realtime_power:
+      type: home_assistant
+      entity: sensor.ev_charger_power
+    state_of_charge_pct:
+      type: home_assistant
+      entity: sensor.ev_soc
+    switch_penalty: 0.1
+```
+
+### Optional: multi-resolution horizon
+```yaml
+ems:
+  min_horizon_minutes: 120
+  timestep_minutes: 30
+  high_res_timestep_minutes: 5
+  high_res_horizon_minutes: 120
+```
+
+## 3) Run the API + worker
+```bash
+uv run hass-energy --config config.yaml
+```
+
+### Verify it is running
+```bash
+curl http://localhost:6070/health
+```
+
+### Trigger and inspect a plan
+```bash
+curl -X POST http://localhost:6070/plan/run
+```
+
+```bash
+curl http://localhost:6070/plan/latest
+```
+
+## Docker
+Build and run a containerized instance:
+```bash
+docker build -t hass-energy .
+```
+
+```bash
+docker run --rm -p 6070:6070 \
+  -v "$(pwd)/config.yaml:/config/config.yaml:ro" \
+  -v "$(pwd)/data:/data" \
+  hass-energy
+```
+
+Or with compose:
+```bash
+docker compose up -d
+```
+
+### Docker config notes
+- Ensure `server.host` is `0.0.0.0` in `config.yaml` so the API binds inside the container.
+- Set `data_dir` to `/data` so plans are persisted on the host volume.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 ## Energy Assistant
 
-Home energy management that connects to your sensors, builds a plan, and exposes a small API so you can automate how your home imports, exports, and stores energy. Home Assistant is the only connected platform today.
+Energy Assistant is an experimental home energy management service. It connects to your energy data sources, generates an energy plan, and exposes a small API so you can automate grid import/export and device usage. Home Assistant is the only supported connector today, but the long-term goal is platform-agnostic data ingestion.
 
 ### What it does
-- Pulls live and forecast data from Home Assistant (current integration).
+- Pulls realtime and forecast data from connected sources (Home Assistant today).
 - Builds a plan for grid import/export and device usage.
-- Runs a lightweight API for health checks and plan triggers.
+- Runs a lightweight API for health checks, settings, and plan triggers.
 
 ![Example Plan](docs/assets/example-plan.png)
 
 ### Home Assistant integration
-Energy Assistant includes a Home Assistant integration (early POC) that surfaces plans as entities so you can automate with HA. It lets you view plan outputs and trigger new plans directly from your HA dashboard.
+Energy Assistant includes a Home Assistant integration (early POC) that surfaces plans as entities so you can automate from your HA dashboard. It lets you view plan outputs and trigger new plans directly from Home Assistant while the broader connector ecosystem evolves.
 
 ### Similar projects
 - [EMHASS](https://github.com/davidusb-geek/emhass) – Home Assistant-focused energy management and optimization.
@@ -21,10 +21,7 @@ Energy Assistant includes a Home Assistant integration (early POC) that surfaces
 This is early, unreleased software. The planner is wired but still evolving, so outputs should be treated as experimental.
 
 ### Quickstart
-1. Install uv: `pip install uv`.
-2. Install dependencies: `uv sync --all-extras --dev`.
-3. Create a `config.yaml` (see the example in `README_DEV.md`).
-4. Run the API + worker: `uv run hass-energy --config config.yaml`.
+See [QUICK_START.md](QUICK_START.md) for setup steps, configuration examples, and how to run the API + worker.
 
 ### Docker
 Build and run a containerized instance:
@@ -45,4 +42,4 @@ docker compose up -d
 ```
 
 ### Documentation
-Architecture, configuration schema, and developer workflows live in `README_DEV.md`.
+Architecture, configuration schema details, and developer workflows live in `README_DEV.md`.

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -9,73 +9,14 @@
 - Frontend: not yet built; the repository root is kept flat so a `frontend/` or similar can be added later.
 
 ### Configuration
-A single YAML file (default `config.yaml`) holds server settings, Home Assistant settings, plant definition, and energy settings. It is read once at startup; the API does not write config—edit the YAML directly.
-
-Example:
-```yaml
-server:
-  host: 0.0.0.0
-  port: 6070
-  data_dir: ./data
-homeassistant:
-  base_url: ""
-  token: null
-  verify_tls: true
-  timeout_seconds: 30
-ems:
-  timestep_minutes: 60
-  min_horizon_minutes: 1440
-plant:
-  grid:
-    max_import_kw: 0.0
-    max_export_kw: 0.0
-    realtime_grid_power:
-      type: home_assistant
-      entity: sensor.grid_power
-    realtime_price_import:
-      type: home_assistant
-      entity: sensor.price_import
-    realtime_price_export:
-      type: home_assistant
-      entity: sensor.price_export
-    price_import_forecast:
-      type: home_assistant
-      platform: amberelectric
-      entity: sensor.price_import_forecast
-    price_export_forecast:
-      type: home_assistant
-      platform: amberelectric
-      entity: sensor.price_export_forecast
-  load:
-    realtime_load_power:
-      type: home_assistant
-      entity: sensor.load_power
-    forecast:
-      type: home_assistant
-      platform: historical_average
-      entity: sensor.load_power_15m
-      history_days: 3
-      interval_duration: 60
-      unit: W
-  inverters: []
-loads: []
-```
-
-Optional multi-resolution horizon:
-```yaml
-ems:
-  min_horizon_minutes: 120
-  timestep_minutes: 30
-  high_res_timestep_minutes: 5
-  high_res_horizon_minutes: 120
-```
-
-Plans are written to `<data_dir>/plans/latest.json` from the config file.
+A single YAML file (default `config.yaml`) holds server settings, Home Assistant settings, plant definition, and energy settings. It is read once at startup; the API does not write config—edit the YAML directly. See `QUICK_START.md` for a complete configuration example and setup notes.
 
 ### API surface (initial)
 - `GET /health` – readiness probe.
 - `GET /settings` – retrieve runtime energy settings (read-only; edit YAML to change).
-- `POST /plan/trigger` – run a one-shot plan; returns stub payload while MILP solver is not yet wired.
+- `POST /plan/run` – trigger a plan run.
+- `GET /plan/latest` – fetch the latest plan (404 if none available).
+- `GET /plan/await` – wait for a plan newer than a timestamp.
 
 ### Docker notes
 - Ensure `server.host` is `0.0.0.0` in `config.yaml` so the API binds inside the container.


### PR DESCRIPTION
### Motivation
- Make project positioning clearer by framing Home Assistant as the current connector while emphasizing a long-term platform-agnostic goal. 
- Provide a focused, user-friendly quick-start with a concrete example (inverter with PV + battery and a controlled EV load) so users can get running without hunting through developer docs. 
- Reduce duplication in developer docs by moving the long example out of `README_DEV.md` into a standalone quick-start reference. 

### Description
- Add `QUICK_START.md` containing a full starter `config.yaml` that demonstrates `inverters` (PV + battery), a controlled EV `loads` example, multi-resolution horizon settings, and run/Docker commands. 
- Update `README.md` to reword project description to: connect to "energy data sources" with a note that Home Assistant is the only supported connector today while the project aims to be connector-agnostic. 
- Update `README.md` to point users to `QUICK_START.md` for setup and examples and to slightly tweak the Home Assistant integration blurb to reflect its POC status. 
- Simplify `README_DEV.md` to remove the embedded long config example and instead reference `QUICK_START.md`, and align the initial API surface to the current endpoints (`POST /plan/run`, `GET /plan/latest`, `GET /plan/await`). 

### Testing
- No automated tests were executed because these are documentation-only changes. 
- Changes were validated by inspecting the modified files (`README.md`, `README_DEV.md`, and `QUICK_START.md`) to ensure examples, links, and endpoint names are consistent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69826239da1883318c094cc23e40032f)