### PR TITLE
Update quantizer automations for new entity names

### DIFF
--- a/packages/hass_energy_quantizer.yaml
+++ b/packages/hass_energy_quantizer.yaml
@@ -5,8 +5,8 @@ automation:
     trigger:
       - platform: state
         entity_id:
-          - sensor.energy_assistant_plan_updated
-          - sensor.energy_assistant_plan_status
+          - sensor.plant_updated
+          - sensor.plant_status
       - platform: time_pattern
         minutes: "/1"
     variables:
@@ -18,16 +18,16 @@ automation:
       battery_full_pct: 99.0
 
       plan_age_s: >-
-        {{ (as_timestamp(now()) - as_timestamp(states('sensor.energy_assistant_plan_updated'), default=0)) | int }}
+        {{ (as_timestamp(now()) - as_timestamp(states('sensor.plant_updated'), default=0)) | int }}
       plan_ok: >-
-        {{ states('sensor.energy_assistant_plan_status') == 'Optimal' and plan_age_s < max_age_s }}
+        {{ states('sensor.plant_status') == 'Optimal' and plan_age_s < max_age_s }}
 
       ac_net_kw: "{{ states('sensor.inverter_primary_inverter_net_power')|float(0) }}"
       charge_kw: "{{ states('sensor.inverter_primary_battery_charge_power')|float(0) }}"
       discharge_kw: "{{ states('sensor.inverter_primary_battery_discharge_power')|float(0) }}"
-      grid_export_kw: "{{ states('sensor.energy_assistant_grid_export_power')|float(0) }}"
-      grid_import_kw: "{{ states('sensor.energy_assistant_grid_import_power')|float(0) }}"
-      price_export: "{{ states('sensor.energy_assistant_price_export')|float(0) }}"
+      grid_export_kw: "{{ states('sensor.plant_grid_export_power')|float(0) }}"
+      grid_import_kw: "{{ states('sensor.plant_grid_import_power')|float(0) }}"
+      price_export: "{{ states('sensor.plant_price_export')|float(0) }}"
       no_export: "{{ price_export < 0 }}"
       export_limit_current_kw: "{{ states('number.inverter_modbus_export_limit')|float(0) }}"
       battery_soc_pct: "{{ states('sensor.inverter_primary_battery_soc') | float(0) }}"
@@ -167,8 +167,8 @@ automation:
     trigger:
       - platform: state
         entity_id:
-          - sensor.energy_assistant_plan_updated
-          - sensor.energy_assistant_plan_status
+          - sensor.plant_updated
+          - sensor.plant_status
       - platform: time_pattern
         minutes: "/1"
     variables:
@@ -180,9 +180,9 @@ automation:
       max_amps: 32
 
       plan_age_s: >-
-        {{ (as_timestamp(now()) - as_timestamp(states('sensor.energy_assistant_plan_updated'), default=0)) | int }}
+        {{ (as_timestamp(now()) - as_timestamp(states('sensor.plant_updated'), default=0)) | int }}
       plan_ok: >-
-        {{ states('sensor.energy_assistant_plan_status') == 'Optimal' and plan_age_s < max_age_s }}
+        {{ states('sensor.plant_status') == 'Optimal' and plan_age_s < max_age_s }}
 
       ev_kw: "{{ states('sensor.load_tessie_charge_power')|float(0) }}"
       amps_raw: "{{ (ev_kw * 1000 / (volts * phases)) if ev_kw > eps else 0 }}"


### PR DESCRIPTION
Summary
- adjust the hass_energy_quantizer automation triggers and state checks to use the new `sensor.plant_*` entities instead of the old `sensor.energy_assistant_*` counterparts
- keep the rest of the automation logic unchanged so that fallback behavior continues to align with the new entity naming

Testing
- Not run (not requested)