### PR TITLE
Support amber-express price forecasts

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -97,6 +97,11 @@ plant:
       # Forecast post-processing mode options:
       # - spot, advanced, blend_min, blend_max, blend_mean (or omit for provider default).
       price_forecast_mode: spot
+    # amber-express example:
+    # price_import_forecast:
+    #   type: home_assistant
+    #   platform: amber_express
+    #   entity: sensor.amber_express_price_import_forecast
     price_export_forecast:
       type: home_assistant
       platform: amberelectric
@@ -104,6 +109,11 @@ plant:
       # Forecast post-processing mode options:
       # - spot, advanced, blend_min, blend_max, blend_mean (or omit for provider default).
       price_forecast_mode: spot
+    # amber-express example:
+    # price_export_forecast:
+    #   type: home_assistant
+    #   platform: amber_express
+    #   entity: sensor.amber_express_price_export_forecast
     # Bias grid prices to prefer self-sufficiency by making imports more expensive
     # and exports less attractive by the same margin (e.g. 25% turns $0.20 import
     # into $0.25 and $0.10 export into $0.075).

--- a/src/energy_assistant/ems/EMS_SYSTEM_DESIGN.md
+++ b/src/energy_assistant/ems/EMS_SYSTEM_DESIGN.md
@@ -193,7 +193,7 @@ Supported source types:
 
 Forecast sources map HA data into interval lists:
 
-- **Price forecasts**: `HomeAssistantAmberElectricForecastSource` →
+- **Price forecasts**: `HomeAssistantAmberElectricForecastSource` (official Amber HA schema) or `HomeAssistantAmberExpressForecastSource` (experimental [amber-express](https://github.com/hass-energy/amber-express) schema; `attributes.forecast`) →
   list[`PriceForecastInterval`]
 - **PV forecasts**: `HomeAssistantSolcastForecastSource` →
   list[`PowerForecastInterval`]

--- a/src/energy_assistant/models/plant.py
+++ b/src/energy_assistant/models/plant.py
@@ -6,11 +6,16 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from energy_assistant.lib.source_resolver.hass_source import (
     HomeAssistantAmberElectricForecastSource,
+    HomeAssistantAmberExpressForecastSource,
     HomeAssistantCurrencyEntitySource,
     HomeAssistantHistoricalAverageForecastSource,
     HomeAssistantPercentageEntitySource,
     HomeAssistantPowerKwEntitySource,
     HomeAssistantSolcastForecastSource,
+)
+
+PriceForecastSource = (
+    HomeAssistantAmberElectricForecastSource | HomeAssistantAmberExpressForecastSource
 )
 
 
@@ -79,8 +84,8 @@ class GridConfig(BaseModel):
     realtime_grid_power: HomeAssistantPowerKwEntitySource
     realtime_price_import: HomeAssistantCurrencyEntitySource
     realtime_price_export: HomeAssistantCurrencyEntitySource
-    price_import_forecast: HomeAssistantAmberElectricForecastSource
-    price_export_forecast: HomeAssistantAmberElectricForecastSource
+    price_import_forecast: PriceForecastSource
+    price_export_forecast: PriceForecastSource
     # Grid price bias: sign-aware premium on positive imports and discount on
     # positive exports (negative prices move toward/away from zero accordingly).
     grid_price_bias_pct: float = Field(default=0.0, ge=0, le=100)


### PR DESCRIPTION
This adds support for the experimental **amber-express** Home Assistant forecast schema for grid import/export prices.

**Problem**
Running `energy-assistant --config config.dev.yaml ems solve` could fail with a short-horizon error when using `platform: amber_express` for `plant.grid.price_import_forecast` / `price_export_forecast`.

**Root cause**
`amber-express` sensors expose `attributes.forecast` as a list of timestamped points that can be *mixed resolution* (often 5-minute points near-term and 30-minute points further out) with `interpolation_mode: previous` (hold the last point until the next point).

Our initial mapping treated each point as a fixed-duration interval (based on the first delta). Once the source switched to 30-minute timestamps, this produced gaps at a 5-minute planning timestep, truncating contiguous coverage.

**Fix**
- Add `HomeAssistantAmberExpressForecastSource` to parse `attributes.forecast`.
- Map points to *contiguous piecewise-constant intervals* by setting each interval end to the next point timestamp (falling back to the last observed delta for the final point).
- Expand `GridConfig` to accept either the official Amber HA schema (`platform: amberelectric`) or `amber-express` (`platform: amber_express`).
- Document the config option in `QUICKSTART.md` and source resolver docs.

**Validation**
- `uv run ruff check src custom_components tests`
- `uv run pyright`
- `uv run pytest`
- Manual: `uv run energy-assistant --config config.dev.yaml ems solve`
