### PR TITLE
Add global dependency container for API state

### DIFF
--- a/src/energy_assistant/api/AGENTS.md
+++ b/src/energy_assistant/api/AGENTS.md
@@ -5,10 +5,12 @@ Assumes repo-wide conventions in the repo-root `AGENTS.md`.
 
 Key files:
 - `src/energy_assistant/api/server.py` wires the FastAPI app and mounts routers.
+- `src/energy_assistant/api/dependencies.py` defines typed global app-state and FastAPI dependency getters.
 - `src/energy_assistant/api/routes/` contains domain routers and DTOs.
 
 Conventions:
 - Keep routes split by domain (for example, `plan`, `settings`). Prefer adding a new router over growing a single file.
+- Route handlers should use `energy_assistant.api.dependencies` getters instead of reading `request.app.state.*` directly.
 - Treat `AppConfig` as read-only runtime input. Do not write YAML config from API handlers.
 - Keep planning logic in the worker/EMS packages. Route handlers should trigger or read worker state, not solve directly.
 - If you change API response models or endpoints, update the Home Assistant client in `custom_components/energy_assistant/energy_assistant_client/` to match.

--- a/src/energy_assistant/api/dependencies.py
+++ b/src/energy_assistant/api/dependencies.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request, status
+
+from energy_assistant.models.config import AppConfig
+from energy_assistant.worker import Worker
+
+
+@dataclass(frozen=True, slots=True)
+class GlobalDependencies:
+    config: AppConfig
+    worker: Worker | None
+
+
+def _get_globals(request: Request) -> GlobalDependencies:
+    deps = getattr(request.app.state, "dependencies", None)
+    if deps is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Global dependencies missing",
+        )
+    if not isinstance(deps, GlobalDependencies):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Global dependencies misconfigured",
+        )
+    return deps
+
+
+def get_config(dependencies: Annotated[GlobalDependencies, Depends(_get_globals)]) -> AppConfig:
+    return dependencies.config
+
+
+def get_worker(dependencies: Annotated[GlobalDependencies, Depends(_get_globals)]) -> Worker:
+    worker = dependencies.worker
+    if worker is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Worker not available",
+        )
+    return worker

--- a/src/energy_assistant/api/routes/plan.py
+++ b/src/energy_assistant/api/routes/plan.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 
+from energy_assistant.api.dependencies import get_config, get_worker
 from energy_assistant.api.routes.plan_dto import (
     PlanAwaitResponseDto,
     PlanLatestResponseDto,
@@ -16,26 +17,6 @@ from energy_assistant.models.config import AppConfig
 from energy_assistant.worker import PlanRunState, Worker
 
 router = APIRouter(prefix="/plan", tags=["plan"])
-
-
-def get_worker(request: Request) -> Worker:
-    worker: Worker | None = getattr(request.app.state, "worker", None)
-    if worker:
-        return worker
-    raise HTTPException(
-        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        detail="Worker not available",
-    )
-
-
-def get_app_config(request: Request) -> AppConfig:
-    config: AppConfig | None = getattr(request.app.state, "app_config", None)
-    if config is None:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Config missing",
-        )
-    return config
 
 
 def _run_to_dto(run: PlanRunState) -> PlanRunStateDto:
@@ -60,7 +41,7 @@ async def run_plan(
 @router.get("/latest", response_model=PlanLatestResponseDto)
 async def latest_plan(
     worker: Annotated[Worker, Depends(get_worker)],
-    app_config: Annotated[AppConfig, Depends(get_app_config)],
+    app_config: Annotated[AppConfig, Depends(get_config)],
 ) -> PlanLatestResponseDto:
     latest = await worker.get_latest()
     if latest is None:
@@ -92,7 +73,7 @@ def _parse_since(value: str | None) -> float:
 @router.get("/await", response_model=PlanAwaitResponseDto)
 async def await_plan(
     worker: Annotated[Worker, Depends(get_worker)],
-    app_config: Annotated[AppConfig, Depends(get_app_config)],
+    app_config: Annotated[AppConfig, Depends(get_config)],
     since: str | None = None,
     timeout: int = 30,
 ) -> PlanAwaitResponseDto | Response:

--- a/src/energy_assistant/api/routes/settings.py
+++ b/src/energy_assistant/api/routes/settings.py
@@ -2,26 +2,17 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, status
 
+from energy_assistant.api.dependencies import get_config
 from energy_assistant.models.config import AppConfig, EmsConfig
 
 router = APIRouter(prefix="/settings", tags=["settings"])
 
 
-def get_app_config(request: Request) -> AppConfig:
-    config: AppConfig | None = getattr(request.app.state, "app_config", None)
-    if config is None:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Config missing",
-        )
-    return config
-
-
 @router.get("", response_model=EmsConfig)
 def read_settings(
-    app_config: Annotated[AppConfig, Depends(get_app_config)],
+    app_config: Annotated[AppConfig, Depends(get_config)],
 ) -> EmsConfig:
     return app_config.ems
 

--- a/src/energy_assistant/api/server.py
+++ b/src/energy_assistant/api/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
+from energy_assistant.api.dependencies import GlobalDependencies
 from energy_assistant.api.routes import plan, settings
 from energy_assistant.models.config import AppConfig
 from energy_assistant.worker import Worker
@@ -9,8 +10,7 @@ from energy_assistant.worker import Worker
 
 def create_app(app_config: AppConfig, worker: Worker | None = None) -> FastAPI:
     app = FastAPI(title="Energy Assistant")
-    app.state.app_config = app_config
-    app.state.worker = worker
+    app.state.dependencies = GlobalDependencies(config=app_config, worker=worker)
     app.include_router(plan.router)
     app.include_router(settings.router)
     return app

--- a/src/energy_assistant/worker/AGENTS.md
+++ b/src/energy_assistant/worker/AGENTS.md
@@ -15,7 +15,7 @@ Key files:
 
 Design rules:
 - Keep dependencies explicit. The CLI constructs `Worker(app_config=..., resolver=..., ha_ws_client=...)` and passes it into the API.
-- Do not couple worker code to FastAPI. The API reads worker state via `request.app.state.worker`.
+- Do not couple worker code to FastAPI. The API reads worker state via `energy_assistant.api.dependencies.get_worker` (backed by `app.state.dependencies`).
 - Be careful with concurrency and superseding runs. Price-change triggers may start a new run while another is in progress; stale results must not publish as the latest plan.
 
 Testing:

--- a/tests/energy_assistant/api/test_dependencies.py
+++ b/tests/energy_assistant/api/test_dependencies.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Any, cast
+
+import httpx
+import yaml
+from fastapi import Depends, FastAPI
+
+from energy_assistant.api.dependencies import GlobalDependencies, get_config
+from energy_assistant.api.server import create_app
+from energy_assistant.models.config import AppConfig
+
+
+def _load_fixture_config(tmp_path: Path) -> AppConfig:
+    fixture_path = Path("tests/fixtures/ems/nwhass/ems_config.yaml")
+    loaded_raw: Any = yaml.safe_load(fixture_path.read_text())
+    assert isinstance(loaded_raw, dict)
+    loaded = cast(dict[str, Any], loaded_raw)
+
+    server_raw = loaded.get("server")
+    if not isinstance(server_raw, dict):
+        server: dict[str, Any] = {}
+        loaded["server"] = server
+    else:
+        server = cast(dict[str, Any], server_raw)
+    server["data_dir"] = str(tmp_path)
+
+    return AppConfig.model_validate(loaded)
+
+
+def test_create_app_sets_global_dependencies(tmp_path: Path) -> None:
+    config = _load_fixture_config(tmp_path)
+    app = create_app(app_config=config, worker=None)
+
+    assert hasattr(app.state, "dependencies")
+    deps = app.state.dependencies
+    assert isinstance(deps, GlobalDependencies)
+    assert deps.config is config
+    assert deps.worker is None
+
+
+async def test_settings_uses_get_config_dependency(tmp_path: Path) -> None:
+    config = _load_fixture_config(tmp_path)
+    app = create_app(app_config=config, worker=None)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/settings")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["timestep_minutes"] == config.ems.timestep_minutes
+    assert payload["min_horizon_minutes"] == config.ems.min_horizon_minutes
+
+
+async def test_plan_run_returns_500_without_worker(tmp_path: Path) -> None:
+    config = _load_fixture_config(tmp_path)
+    app = create_app(app_config=config, worker=None)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.post("/plan/run")
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Worker not available"
+
+
+async def test_missing_global_dependencies_returns_500() -> None:
+    app = FastAPI()
+
+    @app.get("/needs-config")
+    def _needs_config(
+        config: Annotated[AppConfig, Depends(get_config)],
+    ) -> dict[str, str]:
+        _ = config
+        return {"ok": "true"}
+
+    _ = _needs_config
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/needs-config")
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Global dependencies missing"


### PR DESCRIPTION
Summary
- add `GlobalDependencies` and shared FastAPI getters to centralize access to config/worker state
- wire app construction to populate `app.state.dependencies` and update the plan/settings routes to rely on the new helpers
- document the dependency pattern and add API tests to cover the new plumbing

Testing
- Not run (not requested)