### PR TITLE
Update amber express example config to use realtime entity

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -100,11 +100,11 @@ plant:
     # amber-express example:
     # realtime_price_import:
     #   type: home_assistant
-    #   entity: sensor.amber_express_price_import
+    #   entity: sensor.price_import
     # price_import_forecast:
     #   type: home_assistant
     #   platform: amber_express
-    #   entity: sensor.amber_express_price_import
+    #   entity: sensor.price_import
     price_export_forecast:
       type: home_assistant
       platform: amberelectric
@@ -115,11 +115,11 @@ plant:
     # amber-express example:
     # realtime_price_export:
     #   type: home_assistant
-    #   entity: sensor.amber_express_price_export
+    #   entity: sensor.price_export
     # price_export_forecast:
     #   type: home_assistant
     #   platform: amber_express
-    #   entity: sensor.amber_express_price_export
+    #   entity: sensor.price_export
     # Bias grid prices to prefer self-sufficiency by making imports more expensive
     # and exports less attractive by the same margin (e.g. 25% turns $0.20 import
     # into $0.25 and $0.10 export into $0.075).

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -98,10 +98,13 @@ plant:
       # - spot, advanced, blend_min, blend_max, blend_mean (or omit for provider default).
       price_forecast_mode: spot
     # amber-express example:
+    # realtime_price_import:
+    #   type: home_assistant
+    #   entity: sensor.amber_express_price_import
     # price_import_forecast:
     #   type: home_assistant
     #   platform: amber_express
-    #   entity: sensor.amber_express_price_import_forecast
+    #   entity: sensor.amber_express_price_import
     price_export_forecast:
       type: home_assistant
       platform: amberelectric
@@ -110,10 +113,13 @@ plant:
       # - spot, advanced, blend_min, blend_max, blend_mean (or omit for provider default).
       price_forecast_mode: spot
     # amber-express example:
+    # realtime_price_export:
+    #   type: home_assistant
+    #   entity: sensor.amber_express_price_export
     # price_export_forecast:
     #   type: home_assistant
     #   platform: amber_express
-    #   entity: sensor.amber_express_price_export_forecast
+    #   entity: sensor.amber_express_price_export
     # Bias grid prices to prefer self-sufficiency by making imports more expensive
     # and exports less attractive by the same margin (e.g. 25% turns $0.20 import
     # into $0.25 and $0.10 export into $0.075).


### PR DESCRIPTION
Summary
- adjust the amber-express examples in `QUICKSTART.md` so the forecast entries reference the same entity as the realtime/current price
- add the matching realtime configuration snippets and remove the redundant note about separate entities

Testing
- Not run (not requested)