### PR TITLE
Make EMS CBC solver configuration deterministic

### DIFF
--- a/src/energy_assistant/ems/planner.py
+++ b/src/energy_assistant/ems/planner.py
@@ -23,6 +23,12 @@ from energy_assistant.inputs.window import InputWindow
 
 logger = logging.getLogger(__name__)
 
+_CBC_RANDOM_SEED = 0
+_CBC_RANDOM_SEED_OPTIONS: tuple[str, ...] = (
+    f"randomSeed {_CBC_RANDOM_SEED}",
+    f"randomCbcSeed {_CBC_RANDOM_SEED}",
+)
+
 
 @dataclass(frozen=True, slots=True)
 class EmsBuiltSnapshot:
@@ -73,7 +79,7 @@ class EmsMilpPlanner:
         built = self.build_snapshot(now=now)
 
         solve_start = time.perf_counter()
-        built.snapshot.problem.solve(pulp.PULP_CBC_CMD(msg=solver_msg))
+        built.snapshot.problem.solve(_build_cbc_solver(msg=solver_msg))
         solve_seconds = time.perf_counter() - solve_start
 
         objective_value = _objective_value(built.snapshot.problem)
@@ -179,3 +185,12 @@ def _format_schedule(
     if high_res_interval is None or high_res_horizon is None:
         return f"{timestep_minutes}m/rest"
     return f"{high_res_interval}m/{high_res_horizon}m, {timestep_minutes}m/rest"
+
+
+def _build_cbc_solver(*, msg: bool) -> pulp.PULP_CBC_CMD:
+    """Build CBC with deterministic settings for scenario replay and CI checks."""
+    return pulp.PULP_CBC_CMD(
+        msg=msg,
+        threads=1,
+        options=list(_CBC_RANDOM_SEED_OPTIONS),
+    )

--- a/tests/energy_assistant/ems/system/test_constructor_injection.py
+++ b/tests/energy_assistant/ems/system/test_constructor_injection.py
@@ -15,7 +15,10 @@ from energy_assistant.ems.horizon import HorizonFactory
 from energy_assistant.ems.inputs.alignment import PowerForecastAligner, PriceForecastAligner
 from energy_assistant.ems.inputs.application import EmsInputApplicator
 from energy_assistant.ems.inputs.models import AppliedForecastInput, AppliedInputRegistry
-from energy_assistant.ems.planner import EmsMilpPlanner
+from energy_assistant.ems.planner import (
+    EmsMilpPlanner,
+    _CBC_RANDOM_SEED_OPTIONS,
+)
 from energy_assistant.ems.system.state import SolveStateStore
 from energy_assistant.inputs.registry import ResolvedForecastInput, ResolvedInputRegistry
 from energy_assistant.inputs.window import InputWindow
@@ -289,4 +292,6 @@ def test_planner_uses_injected_runtime_dependencies() -> None:
     assert len(problem.solve_calls) == 1
     solver = problem.solve_calls[0]
     assert isinstance(solver, pulp.PULP_CBC_CMD)
+    assert solver.optionsDict.get("threads") == 1
+    assert solver.options == list(_CBC_RANDOM_SEED_OPTIONS)
     assert plan.status == "Optimal"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- route EMS MILP solves through a dedicated CBC builder in `EmsMilpPlanner`
- force deterministic CBC settings for scenario replay and CI runs (`threads=1`, fixed random seed options)
- extend planner constructor-injection test to assert deterministic solver configuration is applied

## Validation
- `uv run pytest tests/energy_assistant/ems/system/test_constructor_injection.py`
- `EMS_SCENARIO=nwhass/short-horizon-20260202-090658 uv run pytest tests/energy_assistant/ems/fixtures/test_baselines.py::test_fixture_baseline_up_to_date` (still fails with same alternate-optimum mismatch; deterministic settings alone do not eliminate this tie)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1314fdbb-8c9e-481a-a756-f200094add2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1314fdbb-8c9e-481a-a756-f200094add2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

